### PR TITLE
Work around missing Scala 3 artifacts for akka-http 10.2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,11 @@
+val akkaDeps =
+  Seq("akka-actor", "akka-actor-typed", "akka-slf4j", "akka-serialization-jackson", "akka-stream")
+val scala2Deps = Map(
+  "com.typesafe.akka"            -> ("2.6.21", akkaDeps),
+  "com.typesafe"                 -> ("0.6.1", Seq("ssl-config-core")),
+  "com.fasterxml.jackson.module" -> ("2.14.3", Seq("jackson-module-scala"))
+)
+
 lazy val root = project.in(file("."))
   .settings(
     name := "play-scala-3",
@@ -8,4 +16,17 @@ lazy val root = project.in(file("."))
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-akka-http-server" % "2.9.0-M6",
     ),
+    // Work around needed because akka-http 10.2.x is not published for Scala 3
+    excludeDependencies ++=
+      (if (scalaBinaryVersion.value == "3") {
+        scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
+      } else {
+        Seq.empty
+      }),
+    libraryDependencies ++=
+      (if (scalaBinaryVersion.value == "3") {
+        scala2Deps.flatMap(e => e._2._2.map(e._1 %% _ % e._2._1).map(_.cross(CrossVersion.for3Use2_13))).toSeq
+      } else {
+        Seq.empty
+      }),
   )


### PR DESCRIPTION
This is more or less a copy of the workaround in https://github.com/playframework/playframework/commit/78c5bfdb885fab3d82938ddbc38f73c094a6d7ed#diff-9ed9f10e75f274f487467172a335403bc184a1933657912746ad94444ed59dab

That workaround would get applied if you would add the Play sbt plugin to your `project/plugins.sbt` and activate it in your `build.sbt` via `lazy val root = (project in file(".")).enablePlugins(PlayScala)` (or `PlayJava`). This would automatically activate the `PlayAkkaHttpServer` sbt plugin as well which would then apply the above linked workaround automatically.

Since you don't do that that way, but directly depend on `play-akka-http-server` in your `libraryDependencies` you need to make sure to not bring in any `akka`, `ssl-config-core` and `jackson-module-scala` Scala 3 artifacts, but instead their Scala 2 artifacts, otherwise you will end up with the exception you got. So you basically switch some dependencies to Scala 2 even when using Scala 3 (There is no sane way in sbt to do that, so we have to first exclude any Scala 3 artifacts and then include the Scala 2 ones).

Works for me locally on my machine.